### PR TITLE
Evaluate coderefs and insert result in template

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,10 +1,12 @@
 Changes for Perl extension Template-Tiny
 
 {{$NEXT}}
+          - Evaluate coderefs and insert results in template (CROMEDOME).
+            This achieves full feature parity with
+            Dancer2::Template::ForkedImplementation::Tiny.
 
 1.15      2025-06-14 15:33:27Z
-          - Allow configurable start/end tags (CROMEDOME). This achieves full
-            feature parity with Dancer2::Template::ForkedImplementation::Tiny.
+          - Allow configurable start/end tags (CROMEDOME).
 
 1.14      2021-05-02 16:48:45Z
           - add link to Template::Tiny::Strict

--- a/lib/Template/Tiny.pm
+++ b/lib/Template/Tiny.pm
@@ -206,6 +206,9 @@ sub _expression {
 			return '';
 		}
 	}
+
+    # If the last expression is a coderef, execute it.
+    ref $cursor eq 'CODE' and $cursor = $cursor->();
 	return $cursor;
 }
 

--- a/t/07_coderefs.t
+++ b/t/07_coderefs.t
@@ -1,0 +1,32 @@
+#!/usr/bin/perl
+
+use strict;
+BEGIN {
+	$|  = 1;
+	$^W = 1;
+}
+use Test::More tests => 1;
+use Template::Tiny ();
+
+sub process {
+	my $stash    = shift;
+	my $input    = shift;
+	my $expected = shift;
+	my $message  = shift || 'Template processed ok';
+	my $output   = '';
+	Template::Tiny->new->process( \$input, $stash, \$output );
+	is( $output, $expected, $message );
+}
+
+
+
+
+
+######################################################################
+# Main Tests
+
+process( { foo => sub{ return 'World' } }, <<'END_TEMPLATE', <<'END_EXPECTED', 'Coderefs as template values ok' );
+Hello [% foo %]!
+END_TEMPLATE
+Hello World!
+END_EXPECTED


### PR DESCRIPTION
@karenetheridge this is another feature from Dancer2's forked version of Template::Tiny that I missed in the earlier commit. I added a test which we did not have in the Dancer2 repo for evaluating coderefs as template variables.

Let me know if you have questions, concerns, etc. Thank you, and sorry for the oversight!